### PR TITLE
Use Dockerfile in skeleton project

### DIFF
--- a/.scrutinizer.yml
+++ b/.scrutinizer.yml
@@ -1,7 +1,4 @@
 # .scrutinizer.yml
-build:
-    environment:
-        php: '5.5.25'
 
 # enable once code sniffer is updated to >= 2.3.4
 # checks:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,9 @@ before_script:
   - travis_retry composer self-update
   - travis_retry composer update --no-interaction --prefer-source
 
-script: make test-coverage-clover
+script:
+  - composer lint
+  - composer test:coverage-clover
 
 after_script:
   - wget https://scrutinizer-ci.com/ocular.phar

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -46,9 +46,10 @@ $ make test-integration
 $ make test-matrix
 ```
 
-You can get a coverage report in text and HTML by running:
+You can get a coverage report in text, html and clover XML formats:
 
 ```shell
 $ make test-coverage
+$ make test-coverage-html
 $ make test-coverage-clover
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -21,14 +21,14 @@ made them including any relevant information or justifications that will aid the
 
 ## Development Environment
 
-If you need a vagrant box for development, we recommend using [adlawson/vagrantfiles](https://github.com/adlawson/vagrantfiles), for PHP:
+A Dockerfile is included in this repository for development. All make commands use the docker container to run the code.
+An initial setup will need to be run to install the environment:
 
 ```shell
-$ curl -O https://raw.githubusercontent.com/adlawson/vagrantfiles/master/php/Vagrantfile
-$ vagrant up
-$ vagrant ssh
-$ cd /srv
+$ make install
 ```
+
+A complete list of commands can be found by running: `$ make help`
 
 ## Running Tests
 
@@ -42,29 +42,13 @@ Or run individual suites using:
 
 ```shell
 $ make test-unit
-$ make test-functional
+$ make test-integration
+$ make test-matrix
 ```
 
-You can get a coverage report in text:
+You can get a coverage report in text and HTML by running:
 
 ```shell
 $ make test-coverage
-$ make test-unit-coverage
-$ make test-functional-coverage
-```
-
-An HTML coverage report can be written to `tests/report` using:
-
-```shell
-$ make test-coverage-html
-$ make test-unit-coverage-html
-$ make test-functional-coverage-html
-```
-
-For a coverage report in clover XML format use:
-
-```shell
 $ make test-coverage-clover
-$ make test-unit-coverage-clover
-$ make test-functional-coverage-clover
 ```

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,13 @@
+FROM php:5.6-cli
+
+RUN apt-get update && apt-get install -y php5-xdebug --no-install-recommends && rm -r /var/lib/apt/lists/*
+
+RUN docker-php-ext-install mbstring \
+    && curl -s https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer \
+    && echo "zend_extension=$(find / -name xdebug.so)" > /usr/local/etc/php/conf.d/xdebug.ini
+
+ADD . /opt/graze/:package-name
+
+WORKDIR /opt/graze/:package-name
+
+CMD /bin/bash

--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,9 @@ test-integration: ## Run the integration testsuite.
 test-coverage: ## Run all tests and output coverage to the console.
 	$(DOCKER_RUN) composer test:coverage --ansi
 
+test-coverage-html: ## Run all tests and output html results
+	$(DOCKER_RUN) composer test:coverage-html --ansi
+
 test-coverage-clover: ## Run all tests and output clover coverage to file.
 	$(DOCKER_RUN) composer test:coverage-clover --ansi
 

--- a/Makefile
+++ b/Makefile
@@ -7,11 +7,11 @@ VOLUME_MAP := -v $$(pwd):${VOLUME}
 DOCKER_RUN := ${DOCKER} run --rm -t ${VOLUME_MAP} ${DOCKER_REPOSITORY}:latest
 
 .PHONY: install composer clean help
-.PHONY: test lint lint-fix test-unit test-integration test-matrix test-coverage test-coverage-clover
+.PHONY: test lint lint-fix test-unit test-integration test-matrix test-coverage test-coverage-html test-coverage-clover
 
 .SILENT: help
 
-
+# Building
 
 install: ## Download the dependencies then build the image :rocket:.
 	make 'composer-install --optimize-autoloader --ignore-platform-reqs'
@@ -28,6 +28,7 @@ clean: ## Clean up any images.
 	$(DOCKER) rmi ${DOCKER_REPOSITORY}:latest
 
 
+# Testing
 
 test: ## Run the unit and integration testsuites.
 test: lint test-unit test-integration
@@ -62,6 +63,7 @@ test-coverage-clover: ## Run all tests and output clover coverage to file.
 	$(DOCKER_RUN) composer test:coverage-clover --ansi
 
 
+# Help
 
 help: ## Show this help message.
 	echo "usage: make [target] ..."

--- a/README.md
+++ b/README.md
@@ -2,14 +2,14 @@
 
 [![Latest Version on Packagist](https://img.shields.io/packagist/v/graze/:package-name.svg?style=flat-square)](https://packagist.org/packages/graze/:package-name)
 [![Software License](https://img.shields.io/badge/license-MIT-brightgreen.svg?style=flat-square)](LICENSE.md)
-[![Build Status](https://img.shields.io/travis/graze/:package_name/master.svg?style=flat-square)](https://travis-ci.org/graze/:package-name)
+[![Build Status](https://img.shields.io/travis/graze/:package-name/master.svg?style=flat-square)](https://travis-ci.org/graze/:package-name)
 [![Coverage Status](https://img.shields.io/scrutinizer/coverage/g/graze/:package-name.svg?style=flat-square)](https://scrutinizer-ci.com/g/graze/:package-name/code-structure)
 [![Quality Score](https://img.shields.io/scrutinizer/g/graze/:package-name.svg?style=flat-square)](https://scrutinizer-ci.com/g/graze/:package-name)
 [![Total Downloads](https://img.shields.io/packagist/dt/graze/:package-name.svg?style=flat-square)](https://packagist.org/packages/graze/:package-name)
 
 >This is heavily inspired by the skeleton project from [The PHP League](https://github.com/thephpleague/skeleton). With some changes based on our preferences. Thanks to them!
 
->**Note:** Replace `:author-name` `:author-username` `:author-email` `:package-name` `:package-description`, `:scrutinizer-access-token`, `:year` with their correct values in [README.md](README.md), [CHANGELOG.md](CHANGELOG.md), [CONTRIBUTING.md](CONTRIBUTING.md), [LICENSE.md](LICENSE.md), [composer.json](composer.json) and [travis.yml](.travis.yml) files, then delete this blockquote.
+>**Note:** Replace `:author-name` `:author-username` `:author-email` `:package-name` `:package-description`, `:scrutinizer-access-token`, `:year` with their correct values in [README.md](README.md), [CHANGELOG.md](CHANGELOG.md), [CONTRIBUTING.md](CONTRIBUTING.md), [LICENSE.md](LICENSE.md), [composer.json](composer.json), [Dockerfile](Dockerfile) and [travis.yml](.travis.yml) files, then delete this blockquote.
 
 >**To use this skeleton project:**
 ```shell
@@ -29,7 +29,7 @@ to make it clear what the project is trying to achieve and the problems that it 
 Via Composer
 
 ``` bash
-$ composer require graze/:package_name
+$ composer require graze/:package-name
 ```
 
 ## Usage

--- a/composer.json
+++ b/composer.json
@@ -21,10 +21,11 @@
         }
     ],
     "require": {
-        "php": ">=5.5.0"
+        "php": ">=5.6.0"
     },
     "require-dev": {
-        "phpunit/phpunit" : "4.*"
+        "phpunit/phpunit" : "5.*",
+        "squizlabs/php_codesniffer": "^2.5"
     },
     "autoload": {
         "psr-4": {
@@ -35,7 +36,32 @@
         "psr-4": {
             "Graze\\Skeleton\\Test\\": "tests/src",
             "Graze\\Skeleton\\Test\\Unit\\": "tests/unit",
-            "Graze\\Skeleton\\Test\\Functional\\": "tests/functional"
+            "Graze\\Skeleton\\Test\\Integration\\": "tests/integration"
         }
+    },
+    "scripts": {
+        "test": [
+            "composer lint --quiet",
+            "composer test:unit --quiet",
+            "composer test:integration --quiet"
+        ],
+        "test:unit": [
+            "vendor/bin/phpunit --colors=always --testsuite unit"
+        ],
+        "test:integration": [
+            "vendor/bin/phpunit --colors=always --testsuite integration"
+        ],
+        "test:coverage": [
+            "vendor/bin/phpunit --coverage-text"
+        ],
+        "test:coverage-clover": [
+            "vendor/bin/phpunit --coverage-clover=./tests/report/coverage.clover"
+        ],
+        "lint": [
+            "vendor/bin/phpcs -p --standard=PSR2 --warning-severity=0 src/ tests/"
+        ],
+        "lint:auto-fix": [
+            "vendor/bin/phpcbf -p --standard=PSR2 src/ tests/"
+        ]
     }
 }

--- a/composer.json
+++ b/composer.json
@@ -57,6 +57,9 @@
         "test:coverage-clover": [
             "vendor/bin/phpunit --coverage-clover=./tests/report/coverage.clover"
         ],
+        "test:coverage-html": [
+            "vendor/bin/phpunit --coverage-html ./tests/report/html"
+        ],
         "lint": [
             "vendor/bin/phpcs -p --standard=PSR2 --warning-severity=0 src/ tests/"
         ],

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -13,8 +13,8 @@
         <testsuite name="unit">
             <directory>tests/unit</directory>
         </testsuite>
-        <testsuite name="functional">
-            <directory>tests/functional</directory>
+        <testsuite name="integration">
+            <directory>tests/integration</directory>
         </testsuite>
     </testsuites>
     <filter>

--- a/src/Skeleton.php
+++ b/src/Skeleton.php
@@ -8,8 +8,8 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  *
- * @license https://github.com/graze/package-name/blob/master/LICENSE.md
- * @link https://github.com/graze/package-name
+ * @license https://github.com/graze/:package-name/blob/master/LICENSE.md
+ * @link https://github.com/graze/:package-name
  */
 
 namespace Graze\Skeleton;

--- a/tests/integration/ExampleIntegrationTest.php
+++ b/tests/integration/ExampleIntegrationTest.php
@@ -8,15 +8,15 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  *
- * @license https://github.com/graze/package-name/blob/master/LICENSE.md
- * @link https://github.com/graze/package-name
+ * @license https://github.com/graze/:package-name/blob/master/LICENSE.md
+ * @link https://github.com/graze/:package-name
  */
 
-namespace Graze\Skeleton\Test\Functional;
+namespace Graze\Skeleton\Test\Integration;
 
 use Graze\Skeleton\Test\ExampleTestCase;
 
-class ExampleFunctionalTest extends ExampleTestCase
+class ExampleIntegrationTest extends ExampleTestCase
 {
     public function testFileExists()
     {

--- a/tests/src/ExampleTestCase.php
+++ b/tests/src/ExampleTestCase.php
@@ -8,8 +8,8 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  *
- * @license https://github.com/graze/package-name/blob/master/LICENSE.md
- * @link https://github.com/graze/package-name
+ * @license https://github.com/graze/:package-name/blob/master/LICENSE.md
+ * @link https://github.com/graze/:package-name
  */
 
 namespace Graze\Skeleton\Test;

--- a/tests/unit/ExampleUnitTest.php
+++ b/tests/unit/ExampleUnitTest.php
@@ -8,8 +8,8 @@
  * For the full copyright and license information, please view the LICENSE
  * file that was distributed with this source code.
  *
- * @license https://github.com/graze/package-name/blob/master/LICENSE.md
- * @link https://github.com/graze/package-name
+ * @license https://github.com/graze/:package-name/blob/master/LICENSE.md
+ * @link https://github.com/graze/:package-name
  */
 
 namespace Graze\Skeleton\Test\Unit;


### PR DESCRIPTION
Use Docker :boat: 
#### Added
- Include Dockerfile based on php5.6-cli with xdebug enabled, so -coverage can be used
#### Updated
- Updated makefile to use docker run commands
- Updated composer.json to include command for remote building (with travis)
- Updated CONTRIBUTING.md with information on the Dockerfile
- Renaming Functional to Integration tests
#### Fixed
- Fixed some :package_name and missing colons for some :package-name references
#### Removed
- Removed the build from scrutinizer.yml file as travis should be building

@wpillar @sjparkinson @john-n-smith Comments?
