### PR TITLE
Rename 'install' make target to 'setup'

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,10 +22,10 @@ made them including any relevant information or justifications that will aid the
 ## Development Environment
 
 A Dockerfile is included in this repository for development. All make commands use the docker container to run the code.
-An initial setup will need to be run to install the environment:
+An initial step will need to be run to set up the environment:
 
 ```shell
-$ make install
+$ make setup
 ```
 
 A complete list of commands can be found by running: `$ make help`

--- a/Makefile
+++ b/Makefile
@@ -6,14 +6,14 @@ VOLUME := /opt/graze/:package-name
 VOLUME_MAP := -v $$(pwd):${VOLUME}
 DOCKER_RUN := ${DOCKER} run --rm -t ${VOLUME_MAP} ${DOCKER_REPOSITORY}:latest
 
-.PHONY: install composer clean help
+.PHONY: setup composer clean help
 .PHONY: test lint lint-fix test-unit test-integration test-matrix test-coverage test-coverage-html test-coverage-clover
 
 .SILENT: help
 
 # Building
 
-install: ## Download the dependencies then build the image :rocket:.
+setup: ## Download the dependencies then build the image :rocket:.
 	make 'composer-install --optimize-autoloader --ignore-platform-reqs'
 	$(DOCKER) build --tag ${DOCKER_REPOSITORY}:latest .
 


### PR DESCRIPTION
Install implies deploying a piece of software on your machine. The step we
are actually doing is setting up dependencies, hence the rename.